### PR TITLE
Set gif var to null if it doesn't exist

### DIFF
--- a/src/components/Tweet/NewTweet.js
+++ b/src/components/Tweet/NewTweet.js
@@ -104,7 +104,7 @@ export const NewTweet = ({ feed }) => {
           text: tweet.value,
           tags,
           mentions,
-          gif: createGifInput(gif),
+          gif: gif ? createGifInput(gif) : null,
           files: tweetFiles,
         },
       });


### PR DESCRIPTION
Non gif tweets were failing since it was trying to parse an undefined object