### PR TITLE
Issue 31: Update profile by id

### DIFF
--- a/src/components/Profile/EditProfile.js
+++ b/src/components/Profile/EditProfile.js
@@ -58,7 +58,7 @@ export const EditProfile = () => {
   const [currentUser] = useState(JSON.parse(user));
 
   const { loading, error, data } = useQuery(PROFILE, {
-    variables: { handle: currentUser?.handle },
+    variables: { id: currentUser?.id },
   });
 
   if (loading) return <Loader />;

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { useQuery } from '@apollo/client';
-import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import ProfileInfo from "./ProfileInfo";
 import { Tweet } from "../Tweet";
@@ -24,10 +23,9 @@ const Wrapper = styled.div`
 `;
 
 export const Profile = () => {
-  const { handle } = useParams();
-
+  const user = JSON.parse(localStorage.getItem("user"));
   const { loading, error, data } = useQuery(PROFILE, {
-    variables: { handle },
+    variables: { id: user?.id },
   });
 
   if (loading) return <Loader />;

--- a/src/queries/profile/index.js
+++ b/src/queries/profile/index.js
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
 
 export const PROFILE = gql`
-  query profile($handle: String!) {
-    profile(handle: $handle) {
+  query profile($id: String!) {
+    profile(id: $id) {
       id
       publicAddress
       handle

--- a/src/views/Nav.js
+++ b/src/views/Nav.js
@@ -102,7 +102,7 @@ const Wrapper = styled.nav`
 export const Nav = () => {
   const user = JSON.parse(localStorage.getItem("user"));
   const { data } = useQuery(PROFILE, {
-    variables: { handle: user?.handle },
+    variables: { id: user?.id },
   });
 
   return (
@@ -132,7 +132,7 @@ export const Nav = () => {
           </NavLink>
         </li>
         <li>
-          <NavLink activeClassName="selected" to={`/${user?.handle}`}>
+          <NavLink activeClassName="selected" to="/profile">
             <AccountCircleIcon /> <span>Profile</span>
           </NavLink>
         </li>


### PR DESCRIPTION
# Issue 31 Fix

1. Update profile by id. There is an associated change required in the API code.
2. Change the profile URL to `/profile` instead of the user handle as that can get changed on edit.